### PR TITLE
Add support phpunit 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1|^8.0"
+        "phpunit/phpunit": "^7.1|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FFIH64HashTest.php
+++ b/tests/FFIH64HashTest.php
@@ -58,6 +58,9 @@ class FFIH64HashTest extends TestCase
     }
     public function testStaticCall()
     {
+        if(version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Static call is deprecated');
+        }
         $this->assertSame(
             '4fdcca5ddb678139',
             V64::hash('test')

--- a/tests/FFIHashTest.php
+++ b/tests/FFIHashTest.php
@@ -59,6 +59,9 @@ class FFIHashTest extends TestCase
     }
     public function testStaticCall()
     {
+        if(version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Static call is deprecated');
+        }
         $this->assertSame(
             '3e2023cf',
             V32::hash('test')

--- a/tests/HashTest.php
+++ b/tests/HashTest.php
@@ -59,6 +59,9 @@ class HashTest extends TestCase
     }
     public function testStaticCall()
     {
+        if(version_compare(PHP_VERSION, '7.0', '>=')) {
+            $this->markTestSkipped('Static call is deprecated');
+        }
         $this->assertSame(
             '3e2023cf',
             V32::hash('test')


### PR DESCRIPTION
* Add support phpunit 9

* Skip static call test in php >= 7.0, because static call is deprecated
