### PR TITLE
Fix PHP >= 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "xxHash implementation in Pure PHP",
     "type": "library",
     "require": {
-        "php": ">=7.4",
+        "php": ">=7.1",
         "ext-bcmath": "*"
     },
     "require-dev": {


### PR DESCRIPTION
First, thank the author very much. This package has solved a big problem for me.

I don't think the PHP version of this package should be >= 7.4, and the version before 7.4 should also be able to use `exussum12\xxhash\V32`.

At present, when using this package in PHP < 7.4, phpunit will also be required.